### PR TITLE
Update Banner

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -3,7 +3,7 @@ import { MiddlewareConsumer, Module, NestModule } from '@nestjs/common';
 import { GraphQLModule } from '@nestjs/graphql';
 import { MongooseModule } from '@nestjs/mongoose';
 import { graphQlModuleOptions } from './config/graphql.js';
-import { mongoDatabaseName, validatedMongoDatabaseUri } from './config/mongo-database.js';
+import { database } from './config/mongo-database.js';
 import { LoggerModule } from './logger/logger.module.js';
 import { RequestLoggerMiddleware } from './logger/request-logger.middleware.js';
 import { ReadController } from './role-mapper/controller/read.controller.js';
@@ -16,8 +16,8 @@ import { KeycloakModule } from './security/keycloak/keycloak.module.js';
         GraphQLModule.forRoot<ApolloDriverConfig>(graphQlModuleOptions),
         LoggerModule,
         KeycloakModule,
-        MongooseModule.forRoot(validatedMongoDatabaseUri, {
-            dbName: mongoDatabaseName,
+        MongooseModule.forRoot(database.databaseUri, {
+            dbName: database.databaseName,
         }),
         RoleMapperModule,
     ],

--- a/backend/src/config/environment.ts
+++ b/backend/src/config/environment.ts
@@ -3,7 +3,16 @@ import process from 'node:process';
 
 dotenv.config();
 
-const { NODE_ENV, KEYCLOAK_CLIENT_SECRET, LOG_LEVEL, START_DB_SERVER } = process.env;
+const {
+    NODE_ENV,
+    KEYCLOAK_CLIENT_SECRET,
+    LOG_LEVEL,
+    START_DB_SERVER,
+    MONGODB_URI,
+    MONGODB_DATABASE,
+    TEST_MONGODB_URI,
+    TEST_MONGODB_DATABASE,
+} = process.env;
 
 /* eslint-disable @typescript-eslint/naming-convention */
 /**
@@ -14,6 +23,10 @@ export const environment = {
     KEYCLOAK_CLIENT_SECRET,
     LOG_LEVEL,
     START_DB_SERVER,
+    MONGODB_URI,
+    MONGODB_DATABASE,
+    TEST_MONGODB_URI,
+    TEST_MONGODB_DATABASE,
 } as const;
 /* eslint-enable @typescript-eslint/naming-convention */
 

--- a/backend/src/config/node.ts
+++ b/backend/src/config/node.ts
@@ -2,8 +2,10 @@ import { hostname } from 'node:os';
 import { RESOURCES_DIR, config } from './app.js';
 import { environment } from './environment.js';
 import { httpsOptions } from './https.js';
+import { database } from './mongo-database.js';
 
 const { NODE_ENV } = environment;
+const { databaseName } = database;
 
 const computername = hostname();
 // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
@@ -15,4 +17,5 @@ export const nodeConfig = {
     resourcesDir: RESOURCES_DIR,
     httpsOptions,
     nodeEnv: NODE_ENV as 'development' | 'PRODUCTION' | 'production' | 'test' | undefined,
+    databaseName,
 } as const;

--- a/backend/src/logger/banner.service.ts
+++ b/backend/src/logger/banner.service.ts
@@ -21,7 +21,7 @@ export class BannerService implements OnApplicationBootstrap {
      * Beim Bootstrap der Anwendung Informationen und ein Banner ausgeben.
      */
     async onApplicationBootstrap() {
-        const { host, nodeEnv, port } = nodeConfig;
+        const { host, nodeEnv, port, databaseName } = nodeConfig;
 
         try {
             // Banner generieren und mit Farben ausgeben
@@ -38,7 +38,7 @@ export class BannerService implements OnApplicationBootstrap {
         this.#logger.info(chalk.cyan('Umgebung: ') + chalk.yellow(nodeEnv));
         this.#logger.info(chalk.cyan('Host: ') + chalk.yellow(host));
         this.#logger.info(chalk.cyan('Port: ') + chalk.yellow(port.toString()));
-        this.#logger.info(chalk.cyan('Datenbank: ') + chalk.yellow('MongoDB'));
+        this.#logger.info(chalk.cyan('Datenbank: ') + chalk.yellow(databaseName));
         this.#logger.info(
             chalk.cyan('Betriebssystem: ') + chalk.yellow(`${type()} (${release()})`),
         );


### PR DESCRIPTION
Dieser Pull-Request enthält mehrere Änderungen zur Verbesserung der Konfiguration und des Loggings der MongoDB-Datenbank in der Backend-Anwendung. Die wichtigsten Änderungen umfassen das Refactoring der MongoDB-Konfiguration, das Aktualisieren von Umgebungsvariablen und das Modifizieren des Logging-Services, um den Datenbanknamen anzuzeigen.

### Konfigurationsverbesserungen:

* [`backend/src/app.module.ts`](diffhunk://#diff-0c2985c7b189bc65e8ded71e24c833e2d788288beaba00cad243a42ce5c625a2L6-R6): Ersetzte die einzelnen MongoDB-Konfigurationsimporte durch einen einzigen `database`-Import und aktualisierte die `MongooseModule`-Konfiguration, um `database.databaseUri` und `database.databaseName` zu verwenden. [[1]](diffhunk://#diff-0c2985c7b189bc65e8ded71e24c833e2d788288beaba00cad243a42ce5c625a2L6-R6) [[2]](diffhunk://#diff-0c2985c7b189bc65e8ded71e24c833e2d788288beaba00cad243a42ce5c625a2L19-R20)

* [`backend/src/config/mongo-database.ts`](diffhunk://#diff-0d022a1df7c04697c4977bd42c9095225f60217977e67c1b3aef59a42198f9efL1-R45): Refactored die MongoDB-Konfiguration, um ein einzelnes `database`-Objekt zu verwenden, das `databaseUri` und `databaseName` enthält, und fügte eine Hilfsfunktion hinzu, um sicherzustellen, dass Umgebungsvariablen definiert sind.

### Umgebungsvariablen:

* [`backend/src/config/environment.ts`](diffhunk://#diff-ef7a9b02701add98d210afb656db17b911727f9a763a7edc3a7aec983bf465bcL6-R15): Hinzugefügt wurden neue Umgebungsvariablen für die MongoDB-Konfiguration (`MONGODB_URI`, `MONGODB_DATABASE`, `TEST_MONGODB_URI`, `TEST_MONGODB_DATABASE`) und sie wurden im `environment`-Export aufgenommen. [[1]](diffhunk://#diff-ef7a9b02701add98d210afb656db17b911727f9a763a7edc3a7aec983bf465bcL6-R15) [[2]](diffhunk://#diff-ef7a9b02701add98d210afb656db17b911727f9a763a7edc3a7aec983bf465bcR26-R29)

### Logging-Verbesserungen:

* [`backend/src/config/node.ts`](diffhunk://#diff-c21fa881d003635c4547f8ccfd8557a08e546a0c952b91e91335e1f423edc6d1R5-R8): Importierte das `database`-Objekt und fügte `databaseName` in den `nodeConfig`-Export ein. [[1]](diffhunk://#diff-c21fa881d003635c4547f8ccfd8557a08e546a0c952b91e91335e1f423edc6d1R5-R8) [[2]](diffhunk://#diff-c21fa881d003635c4547f8ccfd8557a08e546a0c952b91e91335e1f423edc6d1R20)

* [`backend/src/logger/banner.service.ts`](diffhunk://#diff-d149ab2748038955c0c0e00631bc69ebde33ffb81240db0a48a4a7f8e06fe4d0L24-R24): Aktualisierte den `BannerService`, um `databaseName` statt eines generischen 'MongoDB'-Strings zu protokollieren. [[1]](diffhunk://#diff-d149ab2748038955c0c0e00631bc69ebde33ffb81240db0a48a4a7f8e06fe4d0L24-R24) [[2]](diffhunk://#diff-d149ab2748038955c0c0e00631bc69ebde33ffb81240db0a48a4a7f8e06fe4d0L41-R41)
