### PR TITLE
Testseite für das frontend

### DIFF
--- a/frontend/src/app/test/layout.tsx
+++ b/frontend/src/app/test/layout.tsx
@@ -1,0 +1,18 @@
+import { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Active Directory View',
+  description: 'Organizational Unit Viewer',
+};
+
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/frontend/src/app/test/page.tsx
+++ b/frontend/src/app/test/page.tsx
@@ -1,0 +1,73 @@
+'use client';
+
+import { useQuery } from '@apollo/client';
+import 'bootstrap/dist/css/bootstrap.min.css';
+import { ORG_UNITS } from '../../graphql/queries/get-orgUnits';
+import client from '../../lib/apolloClient';
+import { JSX, useState } from 'react';
+
+type OrgUnit = {
+  _id: string;
+  name: string;
+  parentId: string | null;
+  supervisor: string | null;
+};
+
+export default function OrgUnitsPage() {
+  const { loading, error, data } = useQuery<{ getData: { data: OrgUnit[] } }>(ORG_UNITS, { client });
+
+  // Zustand für geöffnete Einheiten
+  const [expanded, setExpanded] = useState<Record<string, boolean>>({});
+
+  // Funktion zum Umschalten des geöffneten Zustands
+  const toggleExpand = (id: string) => {
+    setExpanded((prev) => ({
+      ...prev,
+      [id]: !prev[id], // Wechsel zwischen true/false
+    }));
+  };
+
+  if (loading) return <div className="alert alert-info">Lade Daten...</div>;
+  if (error) {
+    console.error(error);
+    return (
+      <div className="alert alert-danger">
+        Fehler: {error.message}. Bitte versuche es erneut!
+      </div>
+    );
+  }
+
+  const orgUnits = data?.getData?.data || [];
+
+  // Rekursive Funktion zur Darstellung der Hierarchie
+  const renderTree = (parentId: string | null): JSX.Element[] => {
+    return orgUnits
+      .filter((unit) => unit.parentId === parentId)
+      .map((unit) => (
+        <li key={unit._id} className="list-group-item">
+          <div>
+            <button
+              className="btn btn-link p-0 me-2"
+              onClick={() => toggleExpand(unit._id)} // Knoten öffnen/schließen
+            >
+              {expanded[unit._id] ? '▼' : '▶'} {/* Pfeil-Symbol */}
+            </button>
+            <strong>{unit.name}</strong>
+            {unit.supervisor && <span> - Supervisor: {unit.supervisor}</span>}
+          </div>
+          {expanded[unit._id] && ( // Untergeordnete Elemente anzeigen, wenn geöffnet
+            <ul className="list-group list-group-flush ms-4">
+              {renderTree(unit._id)}
+            </ul>
+          )}
+        </li>
+      ));
+  };
+
+  return (
+    <div className="container mt-4">
+      <h1 className="mb-4">Organisationseinheiten</h1>
+      <ul className="list-group">{renderTree(null)}</ul>
+    </div>
+  );
+}

--- a/frontend/src/graphql/queries/get-orgUnits.ts
+++ b/frontend/src/graphql/queries/get-orgUnits.ts
@@ -1,0 +1,18 @@
+import { gql } from '@apollo/client';
+
+export const ORG_UNITS = gql`
+  query GetData {
+    getData(input: { entity: ORG_UNITS }) {
+        totalCount
+        data {
+            ... on OrgUnit {
+                _id
+                name
+                parentId
+                supervisor
+            }
+        }
+    }
+}
+
+`;

--- a/frontend/src/types/orgUnit.type.ts
+++ b/frontend/src/types/orgUnit.type.ts
@@ -1,0 +1,6 @@
+export interface OrgUnit {
+    _id: string;
+    name: string;
+    parentId: string | null;
+    supervisor: string | null;
+}


### PR DESCRIPTION
Dieser Pull-Request führt eine neue Funktion zum Anzeigen von Organisationseinheiten mit Apollo Client und React ein. Die Änderungen umfassen das Einrichten der Metadaten für die neue Seite, das Definieren der GraphQL-Abfrage und die Implementierung der Hauptseitenkomponente, um die Organisationseinheiten in einer hierarchischen Struktur anzuzeigen.

### Metadaten und Layout-Einrichtung:
* Metadaten für die neue Seite in `frontend/src/app/test/layout.tsx` hinzugefügt, einschließlich Titel und Beschreibung.

### Hauptseitenkomponente:
* Die Komponente `OrgUnitsPage` in `frontend/src/app/test/page.tsx` wurde erstellt, die Apollo Client verwendet, um Organisationseinheiten abzurufen und in einer hierarchischen Liste anzuzeigen.

### GraphQL-Abfrage:
* Die `ORG_UNITS` GraphQL-Abfrage wurde in `frontend/src/graphql/queries/get-orgUnits.ts` definiert, um Daten zu den Organisationseinheiten abzurufen.

### Typdefinitionen:
* Die `OrgUnit` TypeScript-Schnittstelle wurde in `frontend/src/types/orgUnit.type.ts` hinzugefügt, um die Struktur der Organisationseinheitsdaten zu definieren.
