### PR TITLE
Update Tests

### DIFF
--- a/backend/__tests__/role-mapper/mutation-resolver.test.ts
+++ b/backend/__tests__/role-mapper/mutation-resolver.test.ts
@@ -7,7 +7,7 @@ import type { GraphQLRequest } from '@apollo/server';
 import { afterAll, beforeAll, describe, expect, test } from '@jest/globals';
 import { HttpStatus } from '@nestjs/common';
 import axios, { type AxiosInstance, type AxiosResponse } from 'axios';
-import { ENDPOINTS, TEST_MANDATES } from '../test-data.js';
+import { ENDPOINTS, TEST_MANDATES2 } from '../test-data.js';
 import { host, httpsAgent, port, shutdownServer, startServer } from '../testserver.js';
 import type { GraphQLResponseBody } from './query-resolver.test.js';
 
@@ -40,7 +40,7 @@ describe('MutationResolver', () => {
     });
 
     test('[GRAPHQL] createEntity for MANDATES', async () => {
-        const createInput = TEST_MANDATES.create;
+        const createInput = TEST_MANDATES2.create;
 
         const body: GraphQLRequest = {
             query: `
@@ -103,7 +103,7 @@ describe('MutationResolver', () => {
     });
 
     test('[GRAPHQL] updateEntity for MANDATES', async () => {
-        const updateInput = TEST_MANDATES.update;
+        const updateInput = TEST_MANDATES2.update;
         const body: GraphQLRequest = {
             query: `
                 mutation UpdateEntity {
@@ -147,7 +147,7 @@ describe('MutationResolver', () => {
     });
 
     test('[GRAPHQL] deleteEntity for MANDATES', async () => {
-        const deleteInput = TEST_MANDATES.delete;
+        const deleteInput = TEST_MANDATES2.delete;
         const body: GraphQLRequest = {
             query: `
             mutation DeleteEntity {

--- a/backend/__tests__/test-data.ts
+++ b/backend/__tests__/test-data.ts
@@ -112,3 +112,17 @@ export const TEST_MANDATES = {
     },
     delete: [{ field: 'functionName', operator: 'EQ', value: 'name2' }],
 };
+
+export const TEST_MANDATES2 = {
+    create: {
+        functionName: 'Student',
+        orgUnit: 'orgUnit',
+        type: 'asd',
+        users: ['gyca1011'],
+    },
+    update: {
+        filters: [{ field: 'functionName', operator: 'EQ', value: 'Student' }],
+        data: { functionName: 'IWI-Student' },
+    },
+    delete: [{ field: 'functionName', operator: 'EQ', value: 'IWI-Student' }],
+};

--- a/backend/__tests__/testserver.ts
+++ b/backend/__tests__/testserver.ts
@@ -50,7 +50,7 @@ const getFreePort = async (startPort: number): Promise<number> => {
                 resolve(startPort);
             });
         });
-        server.on('error', () => resolve(startPort + 1));
+        server.on('error', () => resolve(getFreePort(startPort + 1)));
     });
 };
 


### PR DESCRIPTION
Dieser Pull-Request enthält Änderungen an den Dateien `backend/__tests__/role-mapper/mutation-resolver.test.ts` und `backend/__tests__/test-data.ts`, um ein neues Set von Testmandaten (`TEST_MANDATES2`) zu verwenden. Zusätzlich enthält er eine Fehlerbehebung in `backend/__tests__/testserver.ts`, um Portkonflikte effektiver zu handhaben.

### Änderungen an den Testmandaten:

* [`backend/__tests__/role-mapper/mutation-resolver.test.ts`](diffhunk://#diff-f954fdc663344f8648adc8a08c56799f77b6d06593407ba4706049c07026619bL10-R10): Referenzen von `TEST_MANDATES` auf `TEST_MANDATES2` für Tests zu Erstellen, Aktualisieren und Löschen von Entitäten aktualisiert. [[1]](diffhunk://#diff-f954fdc663344f8648adc8a08c56799f77b6d06593407ba4706049c07026619bL10-R10) [[2]](diffhunk://#diff-f954fdc663344f8648adc8a08c56799f77b6d06593407ba4706049c07026619bL43-R43) [[3]](diffhunk://#diff-f954fdc663344f8648adc8a08c56799f77b6d06593407ba4706049c07026619bL106-R106) [[4]](diffhunk://#diff-f954fdc663344f8648adc8a08c56799f77b6d06593407ba4706049c07026619bL150-R150)
* [`backend/__tests__/test-data.ts`](diffhunk://#diff-d6ebc0f8c0e9378bb34c46cbe8dc32154d531ed13a31a92e8d82b1bf34a27ac0R115-R128): Ein neues Set von Testmandaten als `TEST_MANDATES2` mit unterschiedlichen Werten für Erstellen, Aktualisieren und Löschen von Operationen hinzugefügt.

### Fehlerbehebung bei Portkonflikten:

* [`backend/__tests__/testserver.ts`](diffhunk://#diff-3907c859f1f4d134fe77600c0aa7d394af6d384ff99bb07dbf874adbbe0a9ccdL53-R53): Die Funktion `getFreePort` wurde geändert, um sich bei einem Fehler rekursiv erneut aufzurufen, um sicherzustellen, dass ein verfügbarer Port gefunden wird.
